### PR TITLE
Option to fetch only new entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,11 @@ The script to generate an XML file works analogously,
 ```
 auxtoxml paper.aux > bibliography.xml
 ```
+
+The script `blgtobib` will fetch only `bibtex` entries which are not already in
+the `.bib` file associated with your project. It uses the `bibtex` log file
+associated with the LaTeX project. For example,
+```
+blgtobib paper.blg >> bibliography.bib
+```
+will append new entries to `bibliography.bib`.

--- a/bin/blgtobib
+++ b/bin/blgtobib
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import argparse
+import inspiretools
+
+parser = argparse.ArgumentParser()
+parser.add_argument("file", help="BibTeX .blg file", type=str)
+args = parser.parse_args()
+
+texkeys = inspiretools.blg2texkey(args.file)
+
+inspiretools.texkey2bib(texkeys)

--- a/inspiretools/functions.py
+++ b/inspiretools/functions.py
@@ -33,6 +33,27 @@ def aux2texkey(filename):
     keys = [x for x in keys if x not in blacklisted_keys]
     return keys
 
+def blg2texkey(filename):
+    keys=[]
+    if not os.path.exists(filename):
+        log.error("File " + filename + " not found.")
+        return keys
+    with open(filename,'r') as f:
+        lines = f.readlines()
+    # regexp to match 'Warning--I didn\'t find a database entry for "..."' (bibtex)
+    # or ? {...} (biber)
+    pattern = re.compile(r'^Warning--I didn\'t find a database entry for \"(?P<keys>[^\"]+)\"')
+    # get nested list of texkeys
+    keys = [re.search(pattern, c).group('keys').split(',')
+            for c in lines if re.match(pattern, c)]
+    # flatten nested list
+    keys = [item for sublist in keys for item in sublist]
+    # remove duplicates
+    keys = list(set(keys))
+    # remove blacklisted keys
+    keys = [x for x in keys if x not in blacklisted_keys]
+    return keys
+
 def onabort():
     print('The reference extraction has been aborted before completion.')
 

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,5 @@ setup(name='inspiretools',
       install_requires=[
         "beautifulsoup4"
       ],
-      scripts=['bin/auxtobib','bin/auxtoxml'],
+      scripts=['bin/auxtobib','bin/auxtoxml','bin/blgtobib'],
       )


### PR DESCRIPTION
I found that downloading the whole database every time was unnecessary and slow. I've added the ability to use the `bibtex` log to check which texkeys aren't in the bibliography database yet and download only those. 
